### PR TITLE
Add nvim-treesitter-context plugin

### DIFF
--- a/nvim/lua/plugins/incline-config.lua
+++ b/nvim/lua/plugins/incline-config.lua
@@ -9,7 +9,7 @@ M.opts = {
             horizontal = 0,
             vertical = 0,
         },
-        zindex = 10,
+        zindex = 50,
     },
     render = function(props)
         local bufname = vim.api.nvim_buf_get_name(props.buf)

--- a/nvim/lua/plugins/treesitter-context-config.lua
+++ b/nvim/lua/plugins/treesitter-context-config.lua
@@ -1,9 +1,6 @@
 local M = {
     'nvim-treesitter/nvim-treesitter-context',
     event = { 'BufReadPost', 'BufNewFile' },
-    dependencies = {
-        'JoosepAlviste/nvim-ts-context-commentstring',
-    }
 }
 
 M.opts = {

--- a/nvim/lua/plugins/treesitter-context-config.lua
+++ b/nvim/lua/plugins/treesitter-context-config.lua
@@ -1,0 +1,15 @@
+local M = {
+    'nvim-treesitter/nvim-treesitter-context',
+    event = { 'BufReadPost', 'BufNewFile' },
+    dependencies = {
+        'JoosepAlviste/nvim-ts-context-commentstring',
+    }
+}
+
+M.opts = {
+    enable = true,
+    max_lines = 5,
+    line_numbers = true,
+}
+
+return M

--- a/nvim/lua/plugins/treesitter-context-config.lua
+++ b/nvim/lua/plugins/treesitter-context-config.lua
@@ -1,6 +1,7 @@
 local M = {
     'nvim-treesitter/nvim-treesitter-context',
     event = { 'BufReadPost', 'BufNewFile' },
+    dependencies = { 'nvim-treesitter' },
 }
 
 M.opts = {


### PR DESCRIPTION
This PR comprises two changes: 1) adding the nvim-treesitter-context plugin and 2) adjusting z-index of the incline.nvim bar. The latter is for always aligning the bar above the context.