### PR TITLE
feat(nvim-telescope): escape string from visual

### DIFF
--- a/nvim/lua/plugins/telescope-config.lua
+++ b/nvim/lua/plugins/telescope-config.lua
@@ -200,7 +200,7 @@ M.keys = function()
         {
             telescope_keymap.grep_workspace,
             function()
-                require('telescope.builtin').grep_string({ default_text = getVisualSelection() })
+                require('telescope.builtin').grep_string({ default_text = getVisualSelection(), use_regex = false })
             end,
             mode = 'v',
         }

--- a/nvim/lua/plugins/telescope-config.lua
+++ b/nvim/lua/plugins/telescope-config.lua
@@ -200,7 +200,7 @@ M.keys = function()
         {
             telescope_keymap.grep_workspace,
             function()
-                require('telescope.builtin').grep_string({ default_text = getVisualSelection(), use_regex = false })
+                require('telescope.builtin').grep_string({ default_text = ("'%s"):format(getVisualSelection()), use_regex = false })
             end,
             mode = 'v',
         }


### PR DESCRIPTION
Make use of the option `use_regex` of the `grep_string `function to automatically escape the string got from visual selection. Obviously, using this wouldn't allow us to use any regular expression.