### PR TITLE
feat(nvim/lsp): cycle vim diagnostic severity

### DIFF
--- a/nvim/lua/plugins/lsp-config.lua
+++ b/nvim/lua/plugins/lsp-config.lua
@@ -168,7 +168,7 @@ local lsp_lines_module = {
 }
 
 lsp_lines_module.init = function()
-    local current_severity = 1
+    local current_severity = vim.diagnostic.severity.HINT
     local function setSeverityConfig(min_severity)
         local config = {}
         if min_severity == 0 then

--- a/nvim/lua/plugins/lsp-config.lua
+++ b/nvim/lua/plugins/lsp-config.lua
@@ -180,7 +180,7 @@ lsp_lines_module.init = function()
     end
 
     vim.api.nvim_create_user_command('LspLinesToggleSeverity', function()
-        current_severity = (current_severity + 1) % 5
+        current_severity = (current_severity + 1) % (#vim.diagnostic.severity + 1)
         setSeverityConfig(current_severity)
         end,
         { nargs = 0 }

--- a/nvim/lua/plugins/lsp-config.lua
+++ b/nvim/lua/plugins/lsp-config.lua
@@ -168,18 +168,20 @@ local lsp_lines_module = {
 }
 
 lsp_lines_module.init = function()
-    local current_filter_status = false
+    local current_severity = 1
     local function setSeverityConfig(min_severity)
-        vim.diagnostic.config({ virtual_lines = { severity = { min = min_severity } } })
+        local config = {}
+        if min_severity == 0 then
+            config.virtual_lines = false
+        else
+            config.virtual_lines = { severity = { min = min_severity } }
+        end
+        vim.diagnostic.config(config)
     end
 
     vim.api.nvim_create_user_command('LspLinesToggleSeverity', function()
-            if current_filter_status then
-                setSeverityConfig(vim.diagnostic.severity.HINT)
-            else
-                setSeverityConfig(vim.diagnostic.severity.WARN)
-            end
-            current_filter_status = not current_filter_status
+        current_severity = (current_severity + 1) % 5
+        setSeverityConfig(current_severity)
         end,
         { nargs = 0 }
     )


### PR DESCRIPTION
The value of min_severity if it's set to `0` through the cycle, it will turn off the virtual lines.