### PR TITLE
fix(nvim/lazy): double virtual texts

### DIFF
--- a/nvim/lua/lazy-config.lua
+++ b/nvim/lua/lazy-config.lua
@@ -57,3 +57,15 @@ require('lazy').setup('plugins', lazy_config)
 -- INFO: lazy.nvim keybinding
 local lazy_keymap = require('config.keymaps').lazy
 vim.keymap.set('n', lazy_keymap.open, '<Cmd>Lazy<CR>')
+
+-- INFO: fix double virtual texts
+vim.api.nvim_create_autocmd("FileType", {
+    pattern = "lazy",
+    callback = function()
+        local floating = vim.api.nvim_win_get_config(0).relative ~= ""
+        vim.diagnostic.config({
+            virtual_text = floating,
+            virtual_lines = not floating,
+        })
+    end,
+})

--- a/nvim/lua/lazy-config.lua
+++ b/nvim/lua/lazy-config.lua
@@ -59,10 +59,10 @@ local lazy_keymap = require('config.keymaps').lazy
 vim.keymap.set('n', lazy_keymap.open, '<Cmd>Lazy<CR>')
 
 -- INFO: fix double virtual texts
-vim.api.nvim_create_autocmd("FileType", {
-    pattern = "lazy",
+vim.api.nvim_create_autocmd('FileType', {
+    pattern = 'lazy',
     callback = function()
-        local floating = vim.api.nvim_win_get_config(0).relative ~= ""
+        local floating = vim.api.nvim_win_get_config(0).relative ~= ''
         vim.diagnostic.config({
             virtual_text = floating,
             virtual_lines = not floating,


### PR DESCRIPTION
# Before
![image](https://user-images.githubusercontent.com/13808339/235442091-429e9217-1caa-4935-83f1-b44a44f5a74f.png)

# After
![image](https://user-images.githubusercontent.com/13808339/235442119-e1a83c6e-bc7b-492d-9039-f7b1a00733e1.png)
