### PR TITLE
chore(nvim/lsp): telemetry was removed, no need to config it

### DIFF
--- a/nvim/lua/plugins/lsp-settings/lua-ls.lua
+++ b/nvim/lua/plugins/lsp-settings/lua-ls.lua
@@ -20,7 +20,6 @@ return {
                 preloadFileSize = 10000,
                 checkThirdParty = false,
             },
-            telemetry = { enable = false },
         },
     },
 }


### PR DESCRIPTION
It was removed since v3.6.5.
https://github.com/LuaLS/lua-language-server/commit/be4dcc0fb3ad331a882f57f20e90bbca30770323