### PR TITLE
fix(sketchybar): comparing app name contains space(s) in spotify script

### DIFF
--- a/sketchybar/plugins/spotify.sh
+++ b/sketchybar/plugins/spotify.sh
@@ -10,7 +10,7 @@ HALF_LENGTH=$(((MAX_LENGTH + 1) / 2))
 update_track() {
   # $INFO comes in malformed or not Spotify app, line below sanitizes it
   CURRENT_APP=$(echo $INFO | jq -r .app)
-  if [ $CURRENT_APP != "Spotify" ]; then
+  if [ "$CURRENT_APP" != "Spotify" ]; then
     sketchybar --set $NAME icon.color=$YELLOW
     return
   fi

--- a/sketchybar/plugins/spotify.sh
+++ b/sketchybar/plugins/spotify.sh
@@ -16,7 +16,7 @@ update_track() {
   fi
 
   PLAYER_STATE=$(echo "$INFO" | jq -r .state)
-  if [ $PLAYER_STATE = "playing" ]; then
+  if [ "$PLAYER_STATE" = "playing" ]; then
     TRACK="$(echo "$INFO" | jq -r .title)"
     ARTIST="$(echo "$INFO" | jq -r .artist)"
 
@@ -41,7 +41,7 @@ update_track() {
     fi
     sketchybar --set $NAME label="${TRACK}  ${ARTIST}" label.drawing=yes icon.color=$GREEN
 
-  elif [ $PLAYER_STATE = "paused" ]; then
+  elif [ "$PLAYER_STATE" = "paused" ]; then
     sketchybar --set $NAME icon.color=$YELLOW
   fi
 }


### PR DESCRIPTION
If `$CURRENT_APP` contains space(s), it would cause this condition to be invalid.